### PR TITLE
fix: fixes for the initial version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # ESP IDF SBOM Vulnerability Scan Action
 
-This action scans manifest files with CPE info in
-repository for possible vulnerabilities.
+This action scans manifest files with CPE info in repository for possible
+vulnerabilities and optionaly sends message to a Mattermost channel.
 
 ## Secrets
 
 ## `SBOM_MATTERMOST_WEBHOOK`
 
-If the `SBOM_MATTERMOST_WEBHOOK` environment variable is set, a brief status message
-containing the job link will automatically be dispatched to the Mattermost
-webhook.
+If the `SBOM_MATTERMOST_WEBHOOK` environment variable is set and not null, a
+brief status message containing the job link will automatically be dispatched
+to the Mattermost webhook. Author of the message is set as
+`${GITHUB_REPOSITORY}@${INPUT_REF:-$GITHUB_REF_NAME}`, where `INPUT_REF` may
+be set via action inputs.
+
+## Inputs
+
+## `ref`
+
+Reference name. If not set `GITHUB_REF_NAME` is used by default. Can be used
+to explicitly set the reference in the Mattermost message user name.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,9 @@ description: 'Scan manifest files with CPE info in repository for possible vulne
 runs:
   using: 'docker'
   image: 'Dockerfile'
+inputs:
+  ref:
+    description: 'Reference name. If not set `GITHUB_REF_NAME` is used by default.'
 outputs:
   vulnerable:
-    description: 'Set to 1 if vulnerability was found, 0 otherwise'
+    description: 'Set to 1 if vulnerability was found or 128 on error, 0 otherwise'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,17 +6,25 @@ die () {
 }
 
 notify_mattermost () {
-	test -n "${SBOM_MATTERMOST_WEBHOOK+x}" || return
+	test -n "${SBOM_MATTERMOST_WEBHOOK:+x}" || return
 
-	if test $1 -eq 0
-	then
+	case $1 in
+	0)
 		MSG=":large_green_circle: No vulnerabilities found"
-	else
+		;;
+	1)
 		MSG=":red_circle: New vulnerabilities found"
-	fi
+		;;
+	128)
+		MSG=":large_yellow_circle: Vulnerabilities scan failed"
+		;;
+	*)
+		MSG=":large_yellow_circle: Unknown return value"
+		;;
+	esac
 
 	JOB_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-	USER_NAME="${GITHUB_REPOSITORY}@${GITHUB_REF_NAME}"
+	USER_NAME="${GITHUB_REPOSITORY}@${INPUT_REF:-$GITHUB_REF_NAME}"
 	curl --no-progress-meter -i -X POST -H 'Content-Type: application/json'\
 		-d "{\"username\": \"${USER_NAME}\", \"text\": \"${MSG} ${JOB_URL}\"}"\
 		"$SBOM_MATTERMOST_WEBHOOK"


### PR DESCRIPTION
This contains three small fixes.

1. We have to distinguish between vulnerable report and esp-idf-sbom error. The esp-idf-sbom tool returned 1 in both cases. This is already handled on the esp-idf-sbom side with internal MR no. 24. With this we can have three states: vulnerable, not vulnerable and error.

2. SBOM_MATTERMOST_WEBHOOK should be tested also for null, not only for unset, because if it's not set in secrets, we would try to sent mattermost message to empty URL.

3. GITHUB_REF_NAME is used by default, but can be overwritten with input "ref" variable. This is needed if one workflow is scanning multiple branches, in which case GITHUB_REF_NAME keeps the same value. GITHUB_REF_NAME is used in user name in the mattermost message, which identifies the repository and branch for which the vulnerability scan was done.
